### PR TITLE
pixdecor: Set button default active to false to avoid unitialized usage

### DIFF
--- a/plugins/pixdecor/deco-button.hpp
+++ b/plugins/pixdecor/deco-button.hpp
@@ -75,7 +75,7 @@ class button_t : public noncopyable_t
 
     button_type_t type;
     wf::simple_texture_t button_texture;
-    bool active;
+    bool active = false;
     wf::geometry_t geometry;
 
     /* Whether the button is currently being hovered */


### PR DESCRIPTION
This is generating multiple valgrind stacktraces of unitialized usage at: 

https://github.com/raspberrypi-ui/wayfire/blob/master/plugins/pixdecor/deco-button.cpp#L67

so better to have some initialization, but didn't get into wich is better true or false. 