### PR TITLE
winshadows: deinit_view when view is unmapped

### DIFF
--- a/plugins/winshadows/shadows.cpp
+++ b/plugins/winshadows/shadows.cpp
@@ -55,6 +55,7 @@ class wayfire_shadows : public wf::plugin_interface_t
             if (view == wayfire_shadows_globals::last_focused_view) {
                 wayfire_shadows_globals::last_focused_view = nullptr;
             }
+            deinit_view(view);
         }
     };
 


### PR DESCRIPTION
So if the view we are attaching a winshadow is unmapped we destroy all the shadow surface data. So if the surface is reused because of a new map the surface data that could have been already freed is not reused.

Synaptic package manager was displaying a Search window dialog, than when closed was just hidden, so the widget was still available but not visible. But when the search window was re-opened it was just unhidden, but the shadow surface data was not correctly initialized as it was already been freed.