### PR TITLE
Automatic headless outputs

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -875,6 +875,11 @@ class output_layout_t::impl
         {
             ensure_noop_output();
         }
+
+        idle_update_configuration.run_once([=] ()
+        {
+            send_wlr_configuration();
+        });
     };
 
     void deinit_noop()

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -643,20 +643,7 @@ struct output_layout_output_t
     /** Check whether the given state can be applied */
     bool test_state(const output_state_t& state)
     {
-        if (state.source == OUTPUT_IMAGE_SOURCE_NONE)
-        {
-            return true;
-        }
-
-        if (state.source == OUTPUT_IMAGE_SOURCE_MIRROR)
-        {
-            return true;
-        }
-
-        /* XXX: are there more things to check? */
-        refresh_custom_modes();
-
-        return is_mode_supported(state.mode);
+        return true;
     }
 
     /** Change the output mode */
@@ -688,8 +675,7 @@ struct output_layout_output_t
                 " for output ", handle->name, ". Trying to use custom mode",
                 "(might not work)");
 
-            wlr_output_set_custom_mode(handle, mode.width, mode.height,
-                mode.refresh);
+            wlr_output_set_custom_mode(handle, mode.width, mode.height, mode.refresh);
         }
 
         wlr_output_commit(handle);
@@ -978,8 +964,17 @@ class output_layout_t::impl
             }
 
             state.source = OUTPUT_IMAGE_SOURCE_SELF;
-            state.mode   = head->state.mode ? *head->state.mode :
-                this->outputs[handle]->current_state.mode;
+
+            if (head->state.mode)
+            {
+                state.mode = *head->state.mode;
+            } else
+            {
+                state.mode.width   = head->state.custom_mode.width;
+                state.mode.height  = head->state.custom_mode.height;
+                state.mode.refresh = head->state.custom_mode.refresh;
+            }
+
             state.position  = {head->state.x, head->state.y};
             state.scale     = head->state.scale;
             state.transform = head->state.transform;

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -418,7 +418,8 @@ struct output_layout_output_t
 
     wlr_output_mode select_default_mode()
     {
-        wlr_output_mode *mode, *fallback;
+        wlr_output_mode *mode;
+        wlr_output_mode *fallback = nullptr;
         int w = 0, h = 0, r = 0;
         wl_list_for_each(mode, &handle->modes, link)
         {
@@ -436,13 +437,9 @@ struct output_layout_output_t
             }
         }
 
-
-        /* Couldn't find a preferred mode. Just return the last, which is
-         * usually also the "largest" */
-        wl_list_for_each_reverse(mode, &handle->modes, link)
-
-        return *fallback;
-        return *mode;
+        if (fallback) {
+            return *fallback;
+        }
 
         /* Finally, if there isn't any mode (for ex. wayland backend),
          * try the wlr_output resolution, falling back to 1200x720

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1409,6 +1409,17 @@ class output_layout_t::impl
             }
         }
 
+        for (auto& entry : config)
+        {
+            auto& handle = entry.first;
+            auto state   = entry.second;
+
+            if (handle == noop_output->handle) {
+                noop_output->apply_state(state);
+                wlr_output_layout_add_auto(output_layout, noop_output->handle);
+            }
+        }
+
         get_core().output_layout->emit_signal("configuration-changed", nullptr);
 
         if (count_enabled > 0)

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -947,13 +947,6 @@ class output_layout_t::impl
         wlr_output_configuration_head_v1 *head;
         wl_list_for_each(head, &configuration->heads, link)
         {
-            if (!this->outputs.count(head->state.output))
-            {
-                LOGE("Output configuration request contains unknown",
-                    " output, probably a compositor bug!");
-                continue;
-            }
-
             auto& handle = head->state.output;
             auto& state  = result[handle];
 
@@ -1253,7 +1246,8 @@ class output_layout_t::impl
     /** Check whether the given configuration can be applied */
     bool test_configuration(const output_configuration_t& config)
     {
-        if (config.size() != this->outputs.size())
+        auto n_outputs = this->outputs.empty() ? 1 : this->outputs.size();
+        if (config.size() != n_outputs)
         {
             return false;
         }
@@ -1261,12 +1255,12 @@ class output_layout_t::impl
         bool ok = true;
         for (auto& entry : config)
         {
-            if (this->outputs.count(entry.first) == 0)
-            {
-                return false;
+            if (this->outputs.count(entry.first) != 0) {
+                ok &= this->outputs[entry.first]->test_state(entry.second);
+            } else if (this->outputs.empty() && noop_output &&
+                    noop_output->handle == entry.first) {
+                ok &= this->noop_output->test_state(entry.second);
             }
-
-            ok &= this->outputs[entry.first]->test_state(entry.second);
         }
 
         /* Check overlapping outputs */
@@ -1334,7 +1328,11 @@ class output_layout_t::impl
         {
             auto& handle = entry.first;
             auto& state  = entry.second;
-            auto& lo     = this->outputs[handle];
+            auto it      = this->outputs.find(handle);
+            if (it == this->outputs.end()) {
+                continue;
+            }
+            auto& lo = it->second;
 
             if (!(state.source & OUTPUT_IMAGE_SOURCE_SELF))
             {
@@ -1354,7 +1352,11 @@ class output_layout_t::impl
         {
             auto& handle = entry.first;
             auto& state  = entry.second;
-            auto& lo     = this->outputs[handle];
+            auto it      = this->outputs.find(handle);
+            if (it == this->outputs.end()) {
+                continue;
+            }
+            auto& lo = it->second;
 
             if (state.source & OUTPUT_IMAGE_SOURCE_SELF &&
                 !entry.second.position.is_automatic_position())
@@ -1375,7 +1377,11 @@ class output_layout_t::impl
         for (auto& entry : config)
         {
             auto& handle = entry.first;
-            auto& lo     = this->outputs[handle];
+            auto it      = this->outputs.find(handle);
+            if (it == this->outputs.end()) {
+                continue;
+            }
+            auto& lo = it->second;
             auto state   = entry.second;
             if (state.source & OUTPUT_IMAGE_SOURCE_SELF &&
                 entry.second.position.is_automatic_position())
@@ -1400,7 +1406,11 @@ class output_layout_t::impl
         {
             auto& handle = entry.first;
             auto& state  = entry.second;
-            auto& lo     = this->outputs[handle];
+            auto it      = this->outputs.find(handle);
+            if (it == this->outputs.end()) {
+                continue;
+            }
+            auto& lo = it->second;
 
             if (state.source == OUTPUT_IMAGE_SOURCE_MIRROR)
             {
@@ -1414,7 +1424,7 @@ class output_layout_t::impl
             auto& handle = entry.first;
             auto state   = entry.second;
 
-            if (handle == noop_output->handle) {
+            if (noop_output && handle == noop_output->handle) {
                 noop_output->apply_state(state);
                 wlr_output_layout_add_auto(output_layout, noop_output->handle);
             }


### PR DESCRIPTION
This automatically creates a headless output instead of relying on NOOP-1.

Headless outputs can be resized, so this will allow VNC clients to set arbitrary modes on the output.

The `auto-headless` plugin will need to be added to the relevant configuration files and the `wayfire-pi` script needs to be modified to enable the headless outputs. Mine looks like this:
```
#!/bin/sh

. /usr/bin/setup_env

export QT_WAYLAND_DISABLE_WINDOWDECORATION=1
export DESKTOP_SESSION=LXDE-pi-wayfire
export WLR_XWAYLAND=/usr/bin/xwayland-xauth
export XAUTHORITY=~/.Xauthority
export WLR_BACKENDS="drm,headless"
export WLR_HEADLESS_OUTPUTS=0

if [ -f "$HOME/.config/gtk-3.0/gtk.css" ] ; then
  rm "$HOME/.config/gtk-3.0/gtk.css"
  sync
fi

if raspi-config nonint gpu_has_mmu ; then
  exec /usr/bin/wayfire $@
else
  exec /usr/bin/wayfire -p $@
fi
```